### PR TITLE
Comments moveapps

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,34 +5,35 @@ MoveApps
 Github repository: https://github.com/ctmm-initiative/moveapps_ctmm_akde/
 
 ## Description
-Calculate an autocorrelated kernel density estimate from a fitted continuous time movement model (ctmm). 
+Calculate an autocorrelated kernel density estimate of your tracked animals' home-ranges from a fitted continuous time movement model (ctmm). 
 
 ## Documentation
-This app is part of a `ctmm`-workflow. The requires a fitted ctmm Model.
+This app is part of a `ctmm`-workflow. It requires that a fitted ctmm model is calculated using the `Fit a Continuous-Time Movement Model (ctmm)` App before running it.
+
+Autocorrelacted kerned density estmates (aKDEs) are estimates of resident animals' range distribution that take into account the autocorrelation of telemetry/tracking data via autocorrelated kernel density estimation. Please see the [AKDE vignette](https://cran.r-project.org/web/packages/ctmm/vignettes/akde.html) or the [publication about the ctmm pacakge and aKDEs](https://doi.org/10.1111/2041-210X.12559) for further details.
 
 ### Input data
 The app requires a *ctmm model with data* as input. 
 
 ### Output data
-
-*Example:* MoveStack in Movebank format
+ctmm UD with Data and Model including the akde UD for all tracks
 
 ### Artefacts
-The app create the following artefacts: 
 
-`homerange.gpkg`: A geopackage with the calculated home ranges.
+`homerange.gpkg`: A geopackage with the calculated akde home ranges.
 
-`akde_summary.txt`: Summary of the calculated home ranges.
-
-
+`akde_summary.txt`: Summary of the calculated home ranges. (PLEASE DEFINE THE DIFFERENT COLUMNS IN THE TABLE - e.g. home range size in km^2...)
 
 
 ### Settings
 
-`Isopleth level`: the isopleth level for which the home range is calculated and shown on the map. 
+`Isopleth level`: the isopleth level for which the home range is calculated and shown on the map. (PLEASE DESCRIBE WHAT ISOPLETH IS)
 
 `Store settings`: click to store the current settings of the app for future workflow runs. 
 
 ### Most common errors
+Please make an issue here if you repeatedly encounter a specific error.
 
 ### Null or error handling
+
+

--- a/appspec.json
+++ b/appspec.json
@@ -3,6 +3,9 @@
   "dependencies": {
     "R": [
       {
+        "name": "shiny"
+      },
+      {
         "name": "dplyr"
       },
       {


### PR DESCRIPTION
Hi @jmsigner and @marcosci, I tiried running the app locally with the co-pilot-sdk.R and I get the error:
`Warning in dir.create(targetDirUDs <- tempdir()) :
  '/tmp/RtmpX8rcDj' already exists`
 `Error in : [writeStart] file exists. You can use 'overwrite=TRUE' to overwrite it` 

Going though the code, maybe the problem could be in L69, were a tem folder is created, but then used twice in L72 and L76.
And looking at the code, I think in L72 the `appArtifactPath` is missing right?

I guess you can merge this branch, and once the code is adjusted I'll have a second look. Thanks!